### PR TITLE
Add scrolling optimisation because mdl does bad stuff

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -193,6 +193,7 @@ h1 {
   text-align: center;
   overflow-x: hidden;
   overflow-y: overlay;
+  will-change: transform;
 }
 
 .timeline-data-rows {


### PR DESCRIPTION
Temporary fix for full screen redraw on scroll using mdl.
google/material-design-lite#828

This fix breaks some of "proper usage" points listed here:
https://developer.mozilla.org/en-US/docs/Web/CSS/will-change