### PR TITLE
Make the isAbsence check rely on the billable field

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -7,6 +7,7 @@ export const FETCH_EMPLOYEES = 'FETCH_EMPLOYEES';
 export const FETCH_PROJECTS = 'FETCH_PROJECTS';
 export const FETCH_HOLIDAYS = 'FETCH_HOLIDAYS';
 export const FETCH_ABSENCE = 'FETCH_ABSENCE';
+export const FETCH_ABSENCE_REASONS = 'FETCH_ABSENCE_REASONS';
 export const FETCH_STAFFING = 'FETCH_STAFFING';
 
 export const SET_TIMELINE = 'SET_TIMELINE';
@@ -58,6 +59,11 @@ export const fetchHolidays = () => ({
 export const fetchAbsence = (fromDate, toDate) => ({
   type: FETCH_ABSENCE,
   payload: api.fetchAbsence(fromDate, toDate)
+});
+
+export const fetchAbsenceReasons = () => ({
+  type: FETCH_ABSENCE_REASONS,
+  payload: api.fetchAbsenceReasons()
 });
 
 export const fetchStaffing = (fromDate, toDate) => ({

--- a/src/apiclient.js
+++ b/src/apiclient.js
@@ -54,6 +54,11 @@ export const fetchAbsence = (fromDate, toDate) => {
   return fetch(endPoint, { headers }).then(response => response.json());
 };
 
+export const fetchAbsenceReasons = () => {
+  const endPoint = `${baseURL}/absence_reasons`;
+  return fetch(endPoint, { headers }).then(response => response.json());
+};
+
 export const addStaffing = (employee, project, year, week, days) =>
   fetch(`${baseURL}/rpc/add_staffing`, {
     method: 'POST',

--- a/src/components/TimelineData.js
+++ b/src/components/TimelineData.js
@@ -4,7 +4,7 @@ import dateFns from 'date-fns';
 import classnames from 'classnames';
 
 import { EmployeeProject } from '../reducers/staffingTool';
-import { isAbsence } from '../selectors';
+import { UNAVAILABLE, BILLABLE } from '../selectors/index';
 
 import AddProjectDialog from './AddProjectDialog';
 
@@ -12,13 +12,12 @@ const TimelineDay = (props) => {
   const events = props.events;
   const eventsStr = events.count() > 0
                  && ` | ${events.map((x) => x.name).join(', ')}`;
-  const absent = events.some((e) => isAbsence(e, props.absenceReasons));
-  const billable = events
-    .some((x) => props.projects.get(x.name, {}).billable === 'billable');
+  const unavailable = events.some((x) => x.billable === UNAVAILABLE);
+  const billable = events.some((x) => x.billable === BILLABLE);
   const dayClassNames = classnames({
     'timeline-data-day': true,
-    'timeline-data-day-event-absent': absent,
-    'timeline-data-day-event-staffed': !absent && events.count() > 0,
+    'timeline-data-day-event-unavailable': unavailable,
+    'timeline-data-day-event-staffed': !unavailable && events.count() > 0,
     'timeline-data-day-event-staffed-billable': billable
   });
   return (
@@ -31,9 +30,7 @@ const TimelineDay = (props) => {
 
 TimelineDay.propTypes = {
   day: React.PropTypes.object.isRequired,
-  events: React.PropTypes.object.isRequired,
-  projects: React.PropTypes.object.isRequired,
-  absenceReasons: React.PropTypes.object.isRequired
+  events: React.PropTypes.object.isRequired
 };
 
 const TimelineWeek = (props) => {
@@ -62,8 +59,6 @@ const TimelineWeek = (props) => {
               key={`day-${x}`}
               day={props.weekDays.get(i)}
               events={props.events.get(x, new List())}
-              projects={props.projects}
-              absenceReasons={props.absenceReasons}
             />
           ))
         }
@@ -76,9 +71,7 @@ TimelineWeek.propTypes = {
   weekSpanPercentage: React.PropTypes.number.isRequired,
   weekDays: React.PropTypes.object.isRequired,
   events: React.PropTypes.object.isRequired,
-  availabilityPerWeek: React.PropTypes.object.isRequired,
-  projects: React.PropTypes.object.isRequired,
-  absenceReasons: React.PropTypes.object.isRequired
+  availabilityPerWeek: React.PropTypes.object.isRequired
 };
 
 const TimelineProject = (props) => (
@@ -155,8 +148,6 @@ const TimelineEmployee = (props) => (
                 events={props.events.get(props.employee.id, new OrderedMap())}
                 availabilityPerWeek={props.availabilityPerWeek
                                           .get(k, new OrderedMap())}
-                projects={props.projects}
-                absenceReasons={props.absenceReasons}
               />
             ))
           }
@@ -210,8 +201,7 @@ TimelineEmployee.propTypes = {
   onToggleExpand: React.PropTypes.func,
   selectedEmployeeProjects: React.PropTypes.object.isRequired,
   selectedWeeks: React.PropTypes.object.isRequired,
-  onSelectEmployeeProjectWeek: React.PropTypes.func.isRequired,
-  absenceReasons: React.PropTypes.object.isRequired
+  onSelectEmployeeProjectWeek: React.PropTypes.func.isRequired
 };
 
 const TimelineData = (props) => {
@@ -236,7 +226,6 @@ const TimelineData = (props) => {
             selectedEmployeeProjects={props.selectedEmployeeProjects}
             selectedWeeks={props.selectedWeeks}
             onSelectEmployeeProjectWeek={props.onSelectEmployeeProjectWeek}
-            absenceReasons={props.absenceReasons}
           />
         ))
       }
@@ -258,8 +247,7 @@ TimelineData.propTypes = {
   onToggleExpand: React.PropTypes.func,
   selectedEmployeeProjects: React.PropTypes.object.isRequired,
   selectedWeeks: React.PropTypes.object.isRequired,
-  onSelectEmployeeProjectWeek: React.PropTypes.func.isRequired,
-  absenceReasons: React.PropTypes.object.isRequired
+  onSelectEmployeeProjectWeek: React.PropTypes.func.isRequired
 };
 
 export default TimelineData;

--- a/src/components/TimelineData.js
+++ b/src/components/TimelineData.js
@@ -12,7 +12,7 @@ const TimelineDay = (props) => {
   const events = props.events;
   const eventsStr = events.count() > 0
                  && ` | ${events.map((x) => x.name).join(', ')}`;
-  const absent = events.some(isAbsence);
+  const absent = events.some((e) => isAbsence(e, props.absenceReasons));
   const billable = events
     .some((x) => props.projects.get(x.name, {}).billable === 'billable');
   const dayClassNames = classnames({
@@ -32,7 +32,8 @@ const TimelineDay = (props) => {
 TimelineDay.propTypes = {
   day: React.PropTypes.object.isRequired,
   events: React.PropTypes.object.isRequired,
-  projects: React.PropTypes.object.isRequired
+  projects: React.PropTypes.object.isRequired,
+  absenceReasons: React.PropTypes.object.isRequired
 };
 
 const TimelineWeek = (props) => {
@@ -62,6 +63,7 @@ const TimelineWeek = (props) => {
               day={props.weekDays.get(i)}
               events={props.events.get(x, new List())}
               projects={props.projects}
+              absenceReasons={props.absenceReasons}
             />
           ))
         }
@@ -75,7 +77,8 @@ TimelineWeek.propTypes = {
   weekDays: React.PropTypes.object.isRequired,
   events: React.PropTypes.object.isRequired,
   availabilityPerWeek: React.PropTypes.object.isRequired,
-  projects: React.PropTypes.object.isRequired
+  projects: React.PropTypes.object.isRequired,
+  absenceReasons: React.PropTypes.object.isRequired
 };
 
 const TimelineProject = (props) => (
@@ -153,6 +156,7 @@ const TimelineEmployee = (props) => (
                 availabilityPerWeek={props.availabilityPerWeek
                                           .get(k, new OrderedMap())}
                 projects={props.projects}
+                absenceReasons={props.absenceReasons}
               />
             ))
           }
@@ -206,7 +210,8 @@ TimelineEmployee.propTypes = {
   onToggleExpand: React.PropTypes.func,
   selectedEmployeeProjects: React.PropTypes.object.isRequired,
   selectedWeeks: React.PropTypes.object.isRequired,
-  onSelectEmployeeProjectWeek: React.PropTypes.func.isRequired
+  onSelectEmployeeProjectWeek: React.PropTypes.func.isRequired,
+  absenceReasons: React.PropTypes.object.isRequired
 };
 
 const TimelineData = (props) => {
@@ -231,6 +236,7 @@ const TimelineData = (props) => {
             selectedEmployeeProjects={props.selectedEmployeeProjects}
             selectedWeeks={props.selectedWeeks}
             onSelectEmployeeProjectWeek={props.onSelectEmployeeProjectWeek}
+            absenceReasons={props.absenceReasons}
           />
         ))
       }
@@ -252,7 +258,8 @@ TimelineData.propTypes = {
   onToggleExpand: React.PropTypes.func,
   selectedEmployeeProjects: React.PropTypes.object.isRequired,
   selectedWeeks: React.PropTypes.object.isRequired,
-  onSelectEmployeeProjectWeek: React.PropTypes.func.isRequired
+  onSelectEmployeeProjectWeek: React.PropTypes.func.isRequired,
+  absenceReasons: React.PropTypes.object.isRequired
 };
 
 export default TimelineData;

--- a/src/containers/Staffing.js
+++ b/src/containers/Staffing.js
@@ -6,7 +6,7 @@ import FlatButton from 'material-ui/FlatButton';
 import {
   currentDays, currentWeeks, currentMonths, employees, customers, projects,
   projectNames, events, availabilityPerWeek, staffingPerWeek,
-  employeesByProject, projectsByEmployee, summaryPerWeek, absenceReasons
+  employeesByProject, projectsByEmployee, summaryPerWeek
 } from '../selectors';
 
 import {
@@ -268,7 +268,6 @@ class Staffing extends React.PureComponent {
                 selectedWeeks={this.props.selectedWeeks}
                 onSelectEmployeeProjectWeek={this.handleSelectEmployeeProjectWeek}
                 onSetDays={this.handleSetDays}
-                absenceReasons={this.props.absenceReasons}
               />
             )
           }
@@ -303,7 +302,6 @@ Staffing.propTypes = {
   selectedEmployeeProjects: React.PropTypes.object.isRequired,
   selectedWeeks: React.PropTypes.object.isRequired,
   summaryPerWeek: React.PropTypes.object.isRequired,
-  absenceReasons: React.PropTypes.object.isRequired,
 
   fetchProjects: React.PropTypes.func.isRequired,
   fetchEmployees: React.PropTypes.func.isRequired,
@@ -337,7 +335,6 @@ const mapStateToProps = (state) => ({
   events: events(state),
   timeline: state.timeline,
   availabilityPerWeek: availabilityPerWeek(state),
-  absenceReasons: absenceReasons(state),
   staffingPerWeek: staffingPerWeek(state),
   employeesByProject: employeesByProject(state),
   projectsByEmployee: projectsByEmployee(state),

--- a/src/containers/Staffing.js
+++ b/src/containers/Staffing.js
@@ -6,11 +6,11 @@ import FlatButton from 'material-ui/FlatButton';
 import {
   currentDays, currentWeeks, currentMonths, employees, customers, projects,
   projectNames, events, availabilityPerWeek, staffingPerWeek,
-  employeesByProject, projectsByEmployee, summaryPerWeek
+  employeesByProject, projectsByEmployee, summaryPerWeek, absenceReasons
 } from '../selectors';
 
 import {
-  fetchProjects, fetchEmployees, fetchHolidays, fetchStaffing, fetchAbsence,
+  fetchProjects, fetchEmployees, fetchHolidays, fetchStaffing, fetchAbsence, fetchAbsenceReasons,
   setTimeline, setTimelineMode, expandCustomers, collapseCustomers,
   expandEmployees, collapseEmployees, staffingToolSelectProjects,
   staffingToolDeselectProjects, staffingToolSelectWeeks,
@@ -58,6 +58,7 @@ class Staffing extends React.PureComponent {
       props.currentDays.first(),
       props.currentDays.last()
     );
+    props.fetchAbsenceReasons();
   }
 
   componentDidMount = () => {
@@ -267,6 +268,7 @@ class Staffing extends React.PureComponent {
                 selectedWeeks={this.props.selectedWeeks}
                 onSelectEmployeeProjectWeek={this.handleSelectEmployeeProjectWeek}
                 onSetDays={this.handleSetDays}
+                absenceReasons={this.props.absenceReasons}
               />
             )
           }
@@ -301,12 +303,14 @@ Staffing.propTypes = {
   selectedEmployeeProjects: React.PropTypes.object.isRequired,
   selectedWeeks: React.PropTypes.object.isRequired,
   summaryPerWeek: React.PropTypes.object.isRequired,
+  absenceReasons: React.PropTypes.object.isRequired,
 
   fetchProjects: React.PropTypes.func.isRequired,
   fetchEmployees: React.PropTypes.func.isRequired,
   fetchHolidays: React.PropTypes.func.isRequired,
   fetchStaffing: React.PropTypes.func.isRequired,
   fetchAbsence: React.PropTypes.func.isRequired,
+  fetchAbsenceReasons: React.PropTypes.func.isRequired,
   setTimeline: React.PropTypes.func.isRequired,
   setTimelineMode: React.PropTypes.func.isRequired,
   expandCustomers: React.PropTypes.func.isRequired,
@@ -333,6 +337,7 @@ const mapStateToProps = (state) => ({
   events: events(state),
   timeline: state.timeline,
   availabilityPerWeek: availabilityPerWeek(state),
+  absenceReasons: absenceReasons(state),
   staffingPerWeek: staffingPerWeek(state),
   employeesByProject: employeesByProject(state),
   projectsByEmployee: projectsByEmployee(state),
@@ -347,6 +352,7 @@ const mapDispatchToProps = {
   fetchHolidays,
   fetchStaffing,
   fetchAbsence,
+  fetchAbsenceReasons,
   setTimeline,
   setTimelineMode,
   expandCustomers,

--- a/src/reducers/absenceReasons.js
+++ b/src/reducers/absenceReasons.js
@@ -1,0 +1,21 @@
+import { OrderedMap } from 'immutable';
+
+import { FETCH_ABSENCE_REASONS } from '../actions';
+
+const initialState = {
+  loading: true,
+  data: new OrderedMap()
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_ABSENCE_REASONS:
+      return {
+        loading: false,
+        data: new OrderedMap(action.payload.map((x) => [x.id, x]))
+          .sortBy((x) => x.id.toLowerCase())
+      };
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import holidays from './holidays';
 import staffing from './staffing';
 import staffingTool from './staffingTool';
 import absence from './absence';
+import absenceReasons from './absenceReasons';
 import timeline from './timeline';
 
 export default {
@@ -15,5 +16,6 @@ export default {
   staffing,
   staffingTool,
   absence,
+  absenceReasons,
   timeline
 };

--- a/styles/main.less
+++ b/styles/main.less
@@ -325,7 +325,7 @@ h1 {
   background-color: #ccf;
 }
 
-.timeline-data-day-event-absent {
+.timeline-data-day-event-unavailable {
   background-color: #fcc;
 }
 


### PR DESCRIPTION
The absence_reasons view in the DB noe holds the only truth
about what is absence. We only want the codes where the
billable field is unavailable to be regarded as absence. This
affects the available time calculation, and therefor also
the faktureringsgrad. Also the styling is affected.