### PR TITLE
Fix bug in available time on employment dates and termination dates

### DIFF
--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -64,9 +64,9 @@ export const events = createSelector(
 const getAvailability = (projects, e, weekDays, evts) => {
   const weekDayStrs = weekDays
           .filter((x) =>
-                  dateFns.isAfter(x, dateFns.parse(e.date_of_employment)))
+                  !dateFns.isBefore(x, dateFns.parse(e.date_of_employment)))
           .filter((x) => !e.termination_date ||
-                  dateFns.isBefore(x, dateFns.parse(e.termination_date)))
+                  !dateFns.isAfter(x, dateFns.parse(e.termination_date)))
           .map((x) => dateFns.format(x, 'YYYY-MM-DD'));
   const staffedDays = weekDayStrs
           .filter((x) => evts.get(x, new List())


### PR DESCRIPTION
The exisiting code regarded all dates after date of employment, and
all dates before termination date as available time. This excluded
the actual employment and termination dates. This commit fixes the issue.